### PR TITLE
Fix code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Specify method to define unique args:
 ```ruby
 class MyWorker
   include Resque::Plugins::BetterUnique
-  unique_job :while_executing, timeout: 5.minutes, unique_args: unique_job_arguments
+  unique_job :while_executing, timeout: 5.minutes, unique_args: :unique_job_arguments
 
   private
 


### PR DESCRIPTION
Make the value of `unique_args` a symbol rather than the result of a method call.